### PR TITLE
CQA-187

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.19.1</version>
 				<executions>
 					<execution>
 						<id>verify</id>


### PR DESCRIPTION
Add missing version number for maven-failsafe-plugin in project POM.
