### PR TITLE
CQA-173: added step definition

### DIFF
--- a/src/test/java/org/collectionspace/qa/cucumber/stepDefinitions/StepDefs.java
+++ b/src/test/java/org/collectionspace/qa/cucumber/stepDefinitions/StepDefs.java
@@ -425,4 +425,19 @@ public class StepDefs {
         assertTrue(element.getText().equals(message));
     }
 
+    @And("user clicks on \"([^\"]*)\" in the Used By sidebar")
+    public void and_user_clicks_on_field_in_the_used_by_sidebar(String field) throws Throwable {
+        String xpath = "//div[@class='csc-related-record csc-related-nonVocabularies']//td/a[contains(text(), '" + field +"')]";
+        driver.findElement(By.xpath(xpath)).click();
+        wait.until(textToBePresentInElementLocated(
+                By.className("csc-titleBar-value"), term));
+    }
+
+    @Then("user clicks on \"([^\"]*)\" in the Used By sidebar")
+    public void then_user_clicks_on_field_in_the_used_by_sidebar(String field) throws Throwable {
+        String xpath = "//div[@class='csc-related-record csc-related-nonVocabularies']//td/a[contains(text(), '" + field +"')]";
+        driver.findElement(By.xpath(xpath)).click();
+        wait.until(textToBePresentInElementLocated(
+                By.className("csc-titleBar-value"), term));
+    }
 }


### PR DESCRIPTION
Added the step definition for "user clicks on _____ on the used by sidebar"
I have not tested it, but it was very similar to an existing stepdef.
A potential bug for this test is if that record uses the vocabulary term multiple times as the step definition itself does not specify which one to search for. However, this should not matter as it still links to the page.
